### PR TITLE
Invert default: use 2-stage transform, as the single stage transform is *hard*

### DIFF
--- a/.changeset/tidy-beds-jog.md
+++ b/.changeset/tidy-beds-jog.md
@@ -1,0 +1,5 @@
+---
+"rollup-plugin-glimmer-template-tag": minor
+---
+
+Invert (again) the 2-phase behavior. preprocessOnly will be try by default, and it can be set to false if you want single-file-configuration (at the cost of double babel parse). README has been updated accordingly

--- a/packages/rollup-plugin-glimmer-template-tag/src/rollup-plugin.js
+++ b/packages/rollup-plugin-glimmer-template-tag/src/rollup-plugin.js
@@ -27,6 +27,8 @@ const RELEVANT_EXTENSION_REGEX = /\.g([jt]s)$/;
 export function glimmerTemplateTag(options) {
   let { preprocessOnly } = options || {};
 
+  preprocessOnly ??= true;
+
   return {
     name: 'preprocess-glimmer-template-tag',
     async resolveId(source, importer, options) {

--- a/packages/test-rollup-addon-gjs/rollup.config.mjs
+++ b/packages/test-rollup-addon-gjs/rollup.config.mjs
@@ -14,7 +14,7 @@ export default defineConfig({
   plugins: [
     addon.publicEntrypoints(['**/*.js']),
     addon.appReexports(['components/**/*.js']),
-    glimmerTemplateTag(),
+    glimmerTemplateTag({ preprocessOnly: false }),
     babel({ babelHelpers: 'bundled' }),
     addon.dependencies(),
     addon.clean(),

--- a/packages/test-rollup-addon-gts/rollup.config.mjs
+++ b/packages/test-rollup-addon-gts/rollup.config.mjs
@@ -14,7 +14,7 @@ export default defineConfig({
   plugins: [
     addon.publicEntrypoints(['**/*.js']),
     addon.appReexports(['components/**/*.js']),
-    glimmerTemplateTag(),
+    glimmerTemplateTag({ preprocessOnly: false }),
     typescript({
       transpiler: 'babel',
       // Babel defaults to "guessing" when there is no browserslist past

--- a/packages/test-rollup-addon-split-gts/rollup.config.mjs
+++ b/packages/test-rollup-addon-split-gts/rollup.config.mjs
@@ -14,7 +14,7 @@ export default defineConfig({
   plugins: [
     addon.publicEntrypoints(['**/*.js']),
     addon.appReexports(['components/**/*.js']),
-    glimmerTemplateTag({ preprocessOnly: true }),
+    glimmerTemplateTag(),
     typescript({
       transpiler: 'babel',
       // Babel defaults to "guessing" when there is no browserslist past


### PR DESCRIPTION
From the embroider meeting on Tuesday, 2023-03-28
 - double babel parse is costly + complicated
   - does need to be avoided for apps, but this rollup plugin is presently only for v2 addons
   - could be mitigated if the template-parser and preprocess plugin were written in rust (using SWC)
     - would be good to port transpilation to SWC anyway, vast speed improvements
- having the preprocess separate allows for only one babel parse (which is during normal babel transform) -- allowing this plugin to maybe work for apps later on